### PR TITLE
Eye axes

### DIFF
--- a/code/modelEye/addSpectacleLens.m
+++ b/code/modelEye/addSpectacleLens.m
@@ -43,6 +43,12 @@ function [opticalSystemOut, p] = addSpectacleLens(opticalSystemIn, lensRefractio
 %
 % Examples:
 %{
+    %% Spectacle lens added to correct myopia
+    sceneGeometry = createSceneGeometry('sphericalAmetropia',-2,'spectacleLens',-2);
+    clear figureFlag
+    figureFlag.zLim = [-20 20];
+    figureFlag.hLim = [-15 15];
+    rayTraceCenteredSurfaces([-3.7,0],deg2rad(-15),sceneGeometry.refraction.opticalSystem.p1p2,figureFlag);
 %}
 
 %% input parser

--- a/code/modelEye/compileVirtualImageFunc.m
+++ b/code/modelEye/compileVirtualImageFunc.m
@@ -39,9 +39,9 @@ function compileVirtualImageFunc( varargin )
     	sceneGeometry.refraction.opticalSystem.p1p2, ...
     	sceneGeometry.refraction.opticalSystem.p1p3};
     [virtualEyeWorldPoint, nodalPointIntersectError] = sceneGeometry.refraction.handle( [-3.7 2 0], [0 0 0 2], args{:} );
-    % Test output against value computed on April 10, 2018
-    virtualEyeWorldPointStored = [-3.700000000000000   2.254956600943682  -0.000000790843393];
-    assert(max(abs(virtualEyeWorldPoint - virtualEyeWorldPointStored)) < 1e-6)
+    % Test output against cached value
+    virtualEyeWorldPointCached = [ -3.700000000000000   2.260297326476055  -0.000000817841759];
+    assert(max(abs(virtualEyeWorldPoint - virtualEyeWorldPointCached)) < 1e-6)
 %}
 %{
     % Compare computation time for MATLAB and compiled C code

--- a/code/modelEye/modelEyeParameters.m
+++ b/code/modelEye/modelEyeParameters.m
@@ -224,9 +224,9 @@ switch p.Results.species
         %}
         switch eyeLaterality
             case 'Right'
-                eye.cornea.axis = [2.6539    1.3017   -0.0200];
+                eye.cornea.axis = [3.4582    1.4499   -0.0200];
             case 'Left'
-                eye.cornea.axis = [-2.6539    1.3017   0.0200];
+                eye.cornea.axis = [-3.4582    1.4499   -0.0200];
         end
 
         
@@ -818,6 +818,7 @@ switch p.Results.species
             eye.alpha(1) = fminsearch(objfun_p1p2,5);
             objfun_p1p3 = @(x) visualAxisSlope([eye.alpha(1) -x],eye,'p1p3')^2;
             eye.alpha(2) = fminsearch(objfun_p1p3,2);
+            eye.alpha(3) = 0;
         else
             eye.alpha = p.Results.alphaAngle;
         end

--- a/code/modelEye/plotModelEyeSchematic.m
+++ b/code/modelEye/plotModelEyeSchematic.m
@@ -12,7 +12,7 @@ function figHandle = plotModelEyeSchematic(sceneGeometry, varargin)
 %   sceneGeometry         - A sceneGeometry struct.
 %
 % Optional key/value pairs:
-%  'crossSectionView'     - String. The view to display. Valid choices
+%  'view'     - String. The view to display. Valid choices
 %                           include {'axial','sagittal'};
 %  'newFigure'            - Logical. Determines if we create a new figure.
 %  'plotColor'            - String. Matlab line spec code for line color,
@@ -34,14 +34,14 @@ function figHandle = plotModelEyeSchematic(sceneGeometry, varargin)
     figure
     subplot(2,1,1)
     sceneGeometry = createSceneGeometry('sphericalAmetropia',0);
-    plotModelEyeSchematic(sceneGeometry,'crossSectionView','axial','newFigure',false,'plotColor','k')
+    plotModelEyeSchematic(sceneGeometry,'view','axial','newFigure',false,'plotColor','k')
     sceneGeometry = createSceneGeometry('sphericalAmetropia',-10);
-    plotModelEyeSchematic(sceneGeometry,'crossSectionView','axial','newFigure',false,'plotColor','r')
+    plotModelEyeSchematic(sceneGeometry,'view','axial','newFigure',false,'plotColor','r')
     subplot(2,1,2)
     sceneGeometry = createSceneGeometry('sphericalAmetropia',0);
-    plotModelEyeSchematic(sceneGeometry,'crossSectionView','sagittal','newFigure',false,'plotColor','k')
+    plotModelEyeSchematic(sceneGeometry,'view','sagittal','newFigure',false,'plotColor','k')
     sceneGeometry = createSceneGeometry('sphericalAmetropia',-10);
-    plotModelEyeSchematic(sceneGeometry,'crossSectionView','sagittal','newFigure',false,'plotColor','r')
+    plotModelEyeSchematic(sceneGeometry,'view','sagittal','newFigure',false,'plotColor','r')
 %}
 
 %% input parser
@@ -51,7 +51,7 @@ p = inputParser; p.KeepUnmatched = true;
 p.addRequired('eye',@isstruct);
 
 % Optional
-p.addParameter('crossSectionView','axial',@ischar);
+p.addParameter('view','axial',@ischar);
 p.addParameter('newFigure',true,@islogical);
 p.addParameter('plotColor','k',@ischar);
 
@@ -66,7 +66,7 @@ end
 hold on
 
 % Determine which view we are using
-switch p.Results.crossSectionView
+switch p.Results.view
     case {'axial','Axial','Ax','ax','Horizontal','horizontal','horiz'}
         PdimA = 1;
         PdimB = 2;
@@ -93,7 +93,7 @@ switch p.Results.crossSectionView
         corneaRange = [sceneGeometry.eye.pupil.center(1), 5, -15, 15];
         lensRange = [-10, 0, -5, 5];       
     otherwise
-        error('Not a recognized crossSectionView for the schematic eye');
+        error('Not a recognized view for the schematic eye');
 end
 
 %% Plot the anterior and posterior chambers and the lens
@@ -127,8 +127,8 @@ b = sceneGeometry.eye.lens.nodalPoint.rear(PdimB) -  (sceneGeometry.eye.lens.nod
 xRange = xlim;
 plot(xRange,xRange.*m+b,[':' p.Results.plotColor]);
 
-%% Plot the visual axis when the eye is rotated to -gamma
-[~, ~, sceneWorldPoints, ~, pointLabels] = pupilProjection_fwd([-sceneGeometry.eye.gamma(1) -sceneGeometry.eye.gamma(2) -sceneGeometry.eye.gamma(3) 1], sceneGeometry, 'fullEyeModelFlag',true);
+%% Plot the visual axis when the eye is rotated to -alpha
+[~, ~, sceneWorldPoints, ~, pointLabels] = pupilProjection_fwd([-sceneGeometry.eye.alpha(1) -sceneGeometry.eye.alpha(2) -sceneGeometry.eye.alpha(3) 1], sceneGeometry, 'fullEyeModelFlag',true);
 idx1 = find(strcmp(pointLabels,'fovea'));
 idx2 = find(strcmp(pointLabels,'nodalPointRear'));
 m = (sceneWorldPoints(idx2,SdimB) - sceneWorldPoints(idx1,SdimB)) / (sceneWorldPoints(idx2,SdimA) - sceneWorldPoints(idx1,SdimA));

--- a/code/modelEye/plotModelEyeSchematic.m
+++ b/code/modelEye/plotModelEyeSchematic.m
@@ -128,14 +128,17 @@ xRange = xlim;
 plot(xRange,xRange.*m+b,[':' p.Results.plotColor]);
 
 %% Plot the visual axis when the eye is rotated to -alpha
-[~, ~, sceneWorldPoints, ~, pointLabels] = pupilProjection_fwd([-sceneGeometry.eye.alpha(1) -sceneGeometry.eye.alpha(2) -sceneGeometry.eye.alpha(3) 1], sceneGeometry, 'fullEyeModelFlag',true);
-idx1 = find(strcmp(pointLabels,'fovea'));
-idx2 = find(strcmp(pointLabels,'nodalPointRear'));
-m = (sceneWorldPoints(idx2,SdimB) - sceneWorldPoints(idx1,SdimB)) / (sceneWorldPoints(idx2,SdimA) - sceneWorldPoints(idx1,SdimA));
-b = sceneWorldPoints(idx1,SdimB) -  (sceneWorldPoints(idx1,SdimA) * m);
-xRange = xlim;
-plot(xRange,xRange.*m+b,[':' p.Results.plotColor]);
-
+% This can be used to confirm that we are calculating alpha properly, but
+% usually does not need to be displayed
+%{
+    [~, ~, sceneWorldPoints, ~, pointLabels] = pupilProjection_fwd([-sceneGeometry.eye.alpha(1) -sceneGeometry.eye.alpha(2) -sceneGeometry.eye.alpha(3) 1], sceneGeometry, 'fullEyeModelFlag',true);
+    idx1 = find(strcmp(pointLabels,'fovea'));
+    idx2 = find(strcmp(pointLabels,'nodalPointRear'));
+    m = (sceneWorldPoints(idx2,SdimB) - sceneWorldPoints(idx1,SdimB)) / (sceneWorldPoints(idx2,SdimA) - sceneWorldPoints(idx1,SdimA));
+    b = sceneWorldPoints(idx1,SdimB) -  (sceneWorldPoints(idx1,SdimA) * m);
+    xRange = xlim;
+    plot(xRange,xRange.*m+b,[':' p.Results.plotColor]);
+%}
 
 %% Reference axis
 plot(xRange,[0 0],['-' p.Results.plotColor]);

--- a/code/modelEye/pupilProjection_fwd.m
+++ b/code/modelEye/pupilProjection_fwd.m
@@ -100,7 +100,7 @@ function [pupilEllipseOnImagePlane, imagePoints, sceneWorldPoints, eyeWorldPoint
     % Obtain the pupil ellipse parameters in transparent format
     pupilEllipseOnImagePlane = pupilProjection_fwd(eyePose,sceneGeometry);
     % Test against 4/15/2018 cached result for eyePose [-10 5 0 3]
-    pupilEllipseOnImagePlaneCached = [2.739903247249959e+02 2.215041869179179e+02 1.763654315743883e+04 0.197418612612315 2.108032545222294];
+    pupilEllipseOnImagePlaneCached = [0.027449574316713e+4   0.022183443169719e+4   1.758736766639561e+4   0.000020274195253e+4   0.000212596262636e+4];
     assert(max(abs(pupilEllipseOnImagePlane -  pupilEllipseOnImagePlaneCached)) < 1e-6)
 %}
 %{

--- a/code/modelEye/pupilProjection_inv.m
+++ b/code/modelEye/pupilProjection_inv.m
@@ -101,10 +101,8 @@ function [eyePose, bestMatchEllipseOnImagePlane, centerError, shapeError, areaEr
     % Recover the eye pose from the ellipse
     inverseEyePose = pupilProjection_inv(pupilEllipseOnImagePlane, sceneGeometry);
     % Report the difference between the input and recovered eyePose
-    fprintf('Error in the recovered eye pose (deg azimuth, deg elevation, deg torsion, mm pupil radius) is: \n');
-    eyePose - inverseEyePose
+    fprintf('Test if the absolute error in the eye pose recovered by pupilProjection_inv is less than 1e-4.\n');
     assert(max(abs(eyePose - inverseEyePose)) < 1e-4)
-
 %}
 %{
     %% Calculate the time required for the inverse projection

--- a/code/modelEye/rayTraceCenteredSurfaces.m
+++ b/code/modelEye/rayTraceCenteredSurfaces.m
@@ -105,7 +105,7 @@ function [outputRay, thetas, imageCoords, intersectionCoords] = rayTraceCentered
     sceneGeometry = createSceneGeometry();
     outputRay = rayTraceCenteredSurfaces([-3.7 2], deg2rad(-10), sceneGeometry.refraction.opticalSystem.p1p2, true);
     % Compare the output to value calculated on April 10, 2018
-    outputRayCached = [-0.128318821107929   1.377619055323267; 0.827239365853814   1.082816492019643];
+    outputRayCached = [-0.151947109615718   1.381824292230910; 0.802861112858012   1.084601718565053];
     assert ( max(max(abs(outputRayCached - outputRay))) < 1e-6)
 %}
 %{

--- a/code/modelEye/virtualImageFunc.m
+++ b/code/modelEye/virtualImageFunc.m
@@ -47,9 +47,9 @@ function [virtualEyeWorldPoint, nodalPointIntersectError] = virtualImageFunc( ey
     	sceneGeometry.refraction.opticalSystem.p1p2, ...
     	sceneGeometry.refraction.opticalSystem.p1p3};
     [virtualEyeWorldPoint, nodalPointIntersectError] = sceneGeometry.refraction.handle( [-3.7 2 0], [0 0 0 2], args{:} );
-    % Test output against value computed on April 10, 2018
-    virtualEyeWorldPointStored = [-3.700000000000000   2.254956600943682  -0.000000790843393];
-    assert(max(abs(virtualEyeWorldPoint - virtualEyeWorldPointStored)) < 1e-6)
+    % Test output against cached value
+    virtualEyeWorldPointCached = [ -3.700000000000000   2.260297326476055  -0.000000817841759];
+    assert(max(abs(virtualEyeWorldPoint - virtualEyeWorldPointCached)) < 1e-6)
 %}
 
 

--- a/code/validations/DEMO_eyePoseParams.m
+++ b/code/validations/DEMO_eyePoseParams.m
@@ -67,7 +67,7 @@ for laterality = 1:2
     % Obtain the point that corresponds to the visual axis at the pupil
     % plane
     [~, imagePointsFixationAxis, ~, ~, pointLabelsFixationAxis] = ...
-        pupilProjection_fwd([sceneGeometry.eye.gamma(1) sceneGeometry.eye.gamma(2) 0 3],sceneGeometry,'fullEyeModelFlag',true);
+        pupilProjection_fwd([sceneGeometry.eye.alpha(1) sceneGeometry.eye.alpha(2) 0 3],sceneGeometry,'fullEyeModelFlag',true);
     
     % setup the figure
     subplot(1,2,laterality);

--- a/code/validations/TEST_Mathur2013.m
+++ b/code/validations/TEST_Mathur2013.m
@@ -42,9 +42,24 @@ compileVirtualImageFunc;
 % By having the eye rotate around the corneal apex, we match the conditions
 % of Mathur et al in which the camera was maintained at a constant distance
 % from the corneal apex.
+%
+% We set the eye to have an axial length slightly longer than default. This
+% is because the Mathur data include both emmetropic and myopic subjects.
+% They find that the beta "turning point" of the pupil diameter ratio was
+% at -5.8 degrees for the emmetropic subjects, and at -5.3 for the
+% population as a whole.
+%{
+    myAlphaAzi = @(sg) sg.eye.alpha(1);
+    myObj = @(x) (5.3 - myAlphaAzi(createSceneGeometry('axialLength',x)))^2;
+    axialLength = fminsearch(myObj,25)
+%}
+% We find that an axial length of 25.134 mm yields a model eye with an
+% alpha of 5.3 degrees, thus matching the central tendency of the Mathur
+% population.
 sceneGeometry = createSceneGeometry( ...
     'extrinsicTranslationVector',[0; 0; 100],...
-    'eyeLaterality','Right');
+    'eyeLaterality','Right', ...
+    'axialLength',25.1340);
 sceneGeometry.eye.rotationCenters.azi = [0 0 0];
 sceneGeometry.eye.rotationCenters.ele = [0 0 0];
 
@@ -88,8 +103,8 @@ viewingAngleDeg = -60:1:60;
 % the eye. The coordinates of our model eye are based around the pupil
 % axis. Therfore, we need to calculate a rotation that accounts for the
 % Mathur viewing angle and kappa.
-azimuthsDeg = (-viewingAngleDeg)-sceneGeometry.eye.gamma(1);
-elevationsDeg = zeros(size(viewingAngleDeg))-sceneGeometry.eye.gamma(2);
+azimuthsDeg = (-viewingAngleDeg)-sceneGeometry.eye.alpha(1);
+elevationsDeg = zeros(size(viewingAngleDeg))-sceneGeometry.eye.alpha(2);
 
 % Calculate the diameter ratios and thetas
 [diamRatios, thetas] = calcPupilDiameterRatio(azimuthsDeg,elevationsDeg,pupilDiam,sceneGeometry);


### PR DESCRIPTION
- The coordinates of the fovea are adjusted for posterior chamber size
- The angle alpha between the visual and optic axes is now derived by reference to the foveal location
- Alpha angle now varies with eye axial length, well replicating Tabernero 2007
- The dilated exit pupil now has a small tilt away from vertical, producing improved fits to the Mathur 2013 obliquity component
- Fixed the contact / spectacle lens routines