### PR TITLE
Keeps more pupil perimeters

### DIFF
--- a/stages/applyControlFile.m
+++ b/stages/applyControlFile.m
@@ -13,15 +13,11 @@ function perimeter = applyControlFile(perimeterFileName, controlFileName, correc
 %   according to the control file instructions (if any) for the given
 %   frame.
 % 
-%   Currently available instructions include:
-%     - blink: save out a black frame
-%     - bad: save out a black frame
-%     - glintPatch: cut the portion of the perimeter that intersects the glint
+%   The instructions that modify the perimeter are:
+%     - glintPatch: cut the portion of the perimeter that intersects the
+%       glint
 %     - cut: cut the perimeter using radius and theta given
 %     - ellipse: draw an ellipse with the given params into the frame
-%     - error: if any error occurred while compiling the automatic
-%       instructions the frame won't be corrected, but an error flag will be
-%       displayed for later inspection.
 % 
 %   Note that each line of the control file is set of instructions for one
 %   specifical video frame, identified by the FrameNumber. If there is no
@@ -128,10 +124,12 @@ for ii = 1:nFrames
         for dd=1:length(instructionIdx)
             switch instructions(instructionIdx(dd)).type
                 case 'blink'
-                    thisFrame=blankFrame;
+                    % Leave it unchanged
                 case 'bad'
-                    thisFrame=blankFrame;
+                    % Leave it unchanged
                 case 'error'
+                    % If we are unable to fit an ellipse to this frame, set
+                    % it blank
                     thisFrame=blankFrame;
                 case 'ellipse'
                     % get the instruction params

--- a/stages/makeControlFile.m
+++ b/stages/makeControlFile.m
@@ -407,13 +407,14 @@ parfor (ii = 1:nFrames, nWorkers)
     smallestFittingError = NaN;
     bestFitOnThisSearch= NaN;
     
-    % proceed if the frame is not empty and has not been tagged as a blink
-    if ~ismember(ii,blinkFrames) && ~isempty(Xp)
+    % proceed if the frame is not empty
+    if ~isempty(Xp)
         
         % The try - catch allows processing to proceed if an attempt to
         % fit the ellipse fails
         try
-            % fit an ellipse to the full perimeter using the constrainedEllipseFit
+            % fit an ellipse to the full perimeter using the
+            % constrainedEllipseFit
             [~, originalFittingError] = constrainedEllipseFit(Xp, Yp, ...
                 p.Results.ellipseTransparentLB, ...
                 p.Results.ellipseTransparentUB, ...
@@ -434,8 +435,8 @@ parfor (ii = 1:nFrames, nWorkers)
             candidateRadius=maxRadius - stepReducer;
             minRadius = maxRadius * p.Results.minRadiusProportion;
             
-            % Keep searching until we have a fit of accetable quality, or if
-            % the candidate radius drops below zero
+            % Keep searching until we have a fit of accetable quality, or
+            % if the candidate radius drops below zero
             while stillSearching && candidateRadius > minRadius
                 
                 % Perform a grid search across thetas


### PR DESCRIPTION
We no longer remove the pupil perimeter in the setting of a “blink” or “bad” frame assignment.

This is part of a general effort to retain as many frames and as much of the pupil perimeter until the final stages of processing.