### PR TITLE
Handles video files that are in the online-only state on DropBox

### DIFF
--- a/stages/deinterlaceVideo.m
+++ b/stages/deinterlaceVideo.m
@@ -70,18 +70,27 @@ p.parse(videoInFileName,videoOutFileName,varargin{:})
 % define variables
 bobMode = p.Results.bobMode;
 
-%% Load video to deinterlace and set parameters for output video file.
-
-inObj = VideoReader(videoInFileName);
+%% Prepare the video object
+% Touch the file. If the file is in the "online only" state within a
+% DropBox "smartSync" directory, this action will cause the file to be
+% downloaded and made local. The system will pause during this time. The
+% only effect of this step will be to update the most recent access date of
+% the file. This step is only available on unix-based operating systems
+if isunix
+    sysCommand = ['touch -a ' videoInFileName];
+    system(sysCommand);
+end
+% create the video in object
+videoInObj = VideoReader(videoInFileName);
 
 if p.Results.nFrames == Inf
-    nFrames = floor(inObj.Duration*inObj.FrameRate);
+    nFrames = floor(videoInObj.Duration*videoInObj.FrameRate);
 else
     nFrames = p.Results.nFrames;
 end
 
 Bob = VideoWriter(videoOutFileName);
-Bob.FrameRate = inObj.FrameRate * 2;
+Bob.FrameRate = videoInObj.FrameRate * 2;
 Bob.Quality = 100;
 
 % Alert the user
@@ -102,7 +111,7 @@ for ii = p.Results.startFrame:nFrames
     end
     
     % get the frame
-    tmp = readFrame(inObj);
+    tmp = readFrame(videoInObj);
     
     % if required, convert to gray
     if p.Results.convertToGray

--- a/stages/findGlint.m
+++ b/stages/findGlint.m
@@ -146,8 +146,17 @@ p.addParameter('centroidsAllocation', 5, @isnumeric);
 p.parse(grayVideoName, glintFileName, varargin{:})
 
 
-%% read video file into memory
-% load pupilPerimeter
+%% Prepare the video object
+% Touch the file. If the file is in the "online only" state within a
+% DropBox "smartSync" directory, this action will cause the file to be
+% downloaded and made local. The system will pause during this time. The
+% only effect of this step will be to update the most recent access date of
+% the file. This step is only available on unix-based operating systems
+if isunix
+    sysCommand = ['touch -a ' grayVideoName];
+    system(sysCommand);
+end
+% create the video in object
 videoInObj = VideoReader(grayVideoName);
 % get number of frames
 if p.Results.nFrames == Inf

--- a/stages/findPupilPerimeter.m
+++ b/stages/findPupilPerimeter.m
@@ -126,7 +126,17 @@ p.addParameter('rangeAdjust', 0.05, @isnumeric);
 p.parse(grayVideoName, perimeterFileName, varargin{:})
 
 
-%% Read video file into memory
+%% Open a video object for reading
+% Touch the file. If the file is in the "online only" state within a
+% DropBox "smartSync" directory, this action will cause the file to be
+% downloaded and made local. The system will pause during this time. The
+% only effect of this step will be to update the most recent access date of
+% the file. This step is only available on unix-based operating systems
+if isunix
+    sysCommand = ['touch -a ' grayVideoName];
+    system(sysCommand);
+end
+% create the video in object
 videoInObj = VideoReader(grayVideoName);
 % get number of frames
 if p.Results.nFrames == Inf

--- a/stages/makeFitVideo.m
+++ b/stages/makeFitVideo.m
@@ -117,7 +117,18 @@ else
     sceneGeometry = [];
 end
 
+
 % Open a video object for reading
+% Touch the file. If the file is in the "online only" state within a
+% DropBox "smartSync" directory, this action will cause the file to be
+% downloaded and made local. The system will pause during this time. The
+% only effect of this step will be to update the most recent access date of
+% the file. This step is only available on unix-based operating systems
+if isunix
+    sysCommand = ['touch -a ' videoInFileName];
+    system(sysCommand);
+end
+% create the video in object
 videoInObj = VideoReader(videoInFileName);
 
 % get number of frames


### PR DESCRIPTION
The routines that work with video files now first issue a “touch -a” system command. This command updates the access date for the file, and triggers a sync operation if the file is cloud only. Control to the routine is returned once the file is fully downloaded.

Signed-off-by: gkaguirre <gkaguirre@me.com>