### PR TITLE
Sanitize filename for touch command

### DIFF
--- a/stages/deinterlaceVideo.m
+++ b/stages/deinterlaceVideo.m
@@ -77,9 +77,11 @@ bobMode = p.Results.bobMode;
 % only effect of this step will be to update the most recent access date of
 % the file. This step is only available on unix-based operating systems
 if isunix
-    sysCommand = ['touch -a ' videoInFileName];
+    sanitizedFileName = replace(videoInFileName,{' ','(',')'},{'\ ','\(','\)'});
+    sysCommand = ['touch -a ' sanitizedFileName];
     system(sysCommand);
 end
+
 % create the video in object
 videoInObj = VideoReader(videoInFileName);
 

--- a/stages/findGlint.m
+++ b/stages/findGlint.m
@@ -153,20 +153,25 @@ p.parse(grayVideoName, glintFileName, varargin{:})
 % only effect of this step will be to update the most recent access date of
 % the file. This step is only available on unix-based operating systems
 if isunix
-    sysCommand = ['touch -a ' grayVideoName];
+    sanitizedFileName = replace(grayVideoName,{' ','(',')'},{'\ ','\(','\)'});
+    sysCommand = ['touch -a ' sanitizedFileName];
     system(sysCommand);
 end
+
 % create the video in object
 videoInObj = VideoReader(grayVideoName);
+
 % get number of frames
 if p.Results.nFrames == Inf
     nFrames = floor(videoInObj.Duration*videoInObj.FrameRate);
 else
     nFrames = p.Results.nFrames;
 end
+
 % get video dimensions
 videoSizeX = videoInObj.Width;
 videoSizeY = videoInObj.Height;
+
 % initialize variable to hold the perimeter data
 grayVideo = zeros(videoSizeY,videoSizeX,nFrames,'uint8');
 

--- a/stages/findPupilPerimeter.m
+++ b/stages/findPupilPerimeter.m
@@ -133,20 +133,25 @@ p.parse(grayVideoName, perimeterFileName, varargin{:})
 % only effect of this step will be to update the most recent access date of
 % the file. This step is only available on unix-based operating systems
 if isunix
-    sysCommand = ['touch -a ' grayVideoName];
+    sanitizedFileName = replace(grayVideoName,{' ','(',')'},{'\ ','\(','\)'});
+    sysCommand = ['touch -a ' sanitizedFileName];
     system(sysCommand);
 end
+
 % create the video in object
 videoInObj = VideoReader(grayVideoName);
+
 % get number of frames
 if p.Results.nFrames == Inf
     nFrames = floor(videoInObj.Duration*videoInObj.FrameRate);
 else
     nFrames = p.Results.nFrames;
 end
+
 % get video dimensions
 videoSizeX = videoInObj.Width;
 videoSizeY = videoInObj.Height;
+
 % initialize variable to hold the perimeter data
 grayVideo = zeros(videoSizeY,videoSizeX,nFrames,'uint8');
 % read the video into memory, adjusting gamma and local contrast

--- a/stages/makeFitVideo.m
+++ b/stages/makeFitVideo.m
@@ -125,7 +125,8 @@ end
 % only effect of this step will be to update the most recent access date of
 % the file. This step is only available on unix-based operating systems
 if isunix
-    sysCommand = ['touch -a ' videoInFileName];
+    sanitizedFileName = replace(videoInFileName,{' ','(',')'},{'\ ','\(','\)'});
+    sysCommand = ['touch -a ' sanitizedFileName];
     system(sysCommand);
 end
 % create the video in object


### PR DESCRIPTION
Dropbox has cursed us with a directory name that includes spaces and parentheses. Added a step to sanitize the file path before passing to the system to escape these forbidden characters.

Signed-off-by: gkaguirre <gkaguirre@me.com>